### PR TITLE
Minor change to support CFBuilder

### DIFF
--- a/core/MongoConfig.cfc
+++ b/core/MongoConfig.cfc
@@ -10,7 +10,16 @@
 
 
 
-	 public function init(Array hosts = [{serverName='localhost',serverPort='27017'}], dbName='default_db', MongoFactory="#createObject('DefaultFactory')#"){
+	 /**
+	 * Constructor
+	 * @hosts Defaults to [{serverName='localhost',serverPort='27017'}]
+	 */
+	 public function init(Array hosts, dbName='default_db', MongoFactory="#createObject('DefaultFactory')#"){
+
+	 	if (!structKeyExist(arguments, 'hosts')) {
+			arguments.hosts = [{serverName='localhost',serverPort='27017'}];
+		}
+
 		variables.mongoFactory = arguments.mongoFactory;
 	 	establishHostInfo();
 


### PR DESCRIPTION
I understand how this could be considered immaterial. But, I thought it was important to help adoption as my first inclination was that there was something wrong.

"CFBuilder does not perform syntax highlighting for a document when array/struct are provided as default arguments. Added structKeyExists() check within the function body."

Thanks.
