### PR TITLE
Added getLastError()

### DIFF
--- a/core/Mongo.cfc
+++ b/core/Mongo.cfc
@@ -58,6 +58,19 @@
 	}
 
 	/**
+	* Returns the last error for the current connection.
+	*/
+	function getLastError()
+	{
+		try {
+			local.error = getMongoDB().getLastError();
+		} catch (any e) {
+			writeDump(var=e,output='c:\web\debug.log');
+		}
+
+		return local.error;
+	}
+	/**
 	* For simple mongo _id searches, use findById(), like so:
 
 	  byID = mongo.findById( url.personId, collection );
@@ -103,7 +116,17 @@
 	This function assumes you are using this to *apply* additional changes to the "found" document. If you wish to overwrite, pass overwriteExisting=true. One bristles at the thought
 
 	*/
-	function findAndModify(struct query, struct fields={}, any sort={"_id"=1}, boolean remove=false, struct update, boolean returnNew=true, boolean upsert=false, boolean applySet=true, string collectionName, mongoConfig=""){
+	function findAndModify(struct query, struct fields, any sort, boolean remove=false, struct update, boolean returnNew=true, boolean upsert=false, boolean applySet=true, string collectionName, mongoConfig=""){
+		// Confirm our complex defaults exist
+		local.argumentDefaults = {sort={"_id"=1},fields={}};
+		for(local.k in local.argumentDefaults)
+		{
+			if (!structKeyExists(arguments, local.k))
+			{
+				arguments[local.k] = local.argumentDefaults[local.k];
+			}
+		}
+
 		var collection = getMongoDBCollection(collectionName, mongoConfig);
 		//must apply $set, otherwise old struct is overwritten
 		if( applySet ){
@@ -138,7 +161,14 @@
 
 	  See examples/aggregation/group.cfm for detail
 	*/
-	function group( collectionName, keys, initial, reduce, query={}, keyf="", finalize="" ){
+	function group( collectionName, keys, initial, reduce, query, keyf="", finalize="" ){
+
+		if (!structKeyExists(arguments, 'query'))
+		{
+			arguments.query = {};
+		}
+
+
 		var collection = getMongoDBCollection(collectionName);
 		var dbCommand =
 			{ "group" =
@@ -176,7 +206,21 @@
 
 	  See examples/aggregation/mapReduce for detail
 	*/
-	function mapReduce( collectionName, map, reduce, query={}, sort={}, limit="0", out="", keeptemp="false", finalize="", scope={}, verbose="true", outType="normal"  ){
+	function mapReduce( collectionName, map, reduce, query, sort, limit="0", out="", keeptemp="false", finalize="", scope, verbose="true", outType="normal"  ){
+
+		// Confirm our complex defaults exist
+		local.argumentDefaults = {
+			 query={}
+			,sort={}
+			,scope={}
+		};
+		for(local.k in local.argumentDefaults)
+		{
+			if (!structKeyExists(arguments, local.k))
+			{
+				arguments[local.k] = local.argumentDefaults[local.k];
+			}
+		}
 
 		var dbCommand = mongoUtil.createOrderedDBObject(
 			[
@@ -254,7 +298,13 @@
 
 	Pass upsert=true to create a document if no documents are found that match the query criteria
 	*/
-	function update(doc, collectionName, query={}, upsert=false, multi=false, applySet=true, mongoConfig=""){
+	function update(doc, collectionName, query, upsert=false, multi=false, applySet=true, mongoConfig=""){
+
+		if (!structKeyExists(arguments, 'query'))
+		{
+			arguments.query = {};
+		}
+
 	   var collection = getMongoDBCollection(collectionName, mongoConfig);
 
 	   if( structIsEmpty(query) ){

--- a/core/Mongo.cfc
+++ b/core/Mongo.cfc
@@ -62,13 +62,7 @@
 	*/
 	function getLastError()
 	{
-		try {
-			local.error = getMongoDB().getLastError();
-		} catch (any e) {
-			writeDump(var=e,output='c:\web\debug.log');
-		}
-
-		return local.error;
+		return getMongoDB().getLastError();
 	}
 	/**
 	* For simple mongo _id searches, use findById(), like so:

--- a/core/MongoConfig.cfc
+++ b/core/MongoConfig.cfc
@@ -10,7 +10,16 @@
 
 
 
-	 public function init(Array hosts = [{serverName='localhost',serverPort='27017'}], dbName='default_db', MongoFactory="#createObject('DefaultFactory')#"){
+	 /**
+	 * Constructor
+	 * @hosts Defaults to [{serverName='localhost',serverPort='27017'}]
+	 */
+	 public function init(Array hosts, dbName='default_db', MongoFactory="#createObject('DefaultFactory')#"){
+
+	 	if (!structKeyExist(arguments, 'hosts')) {
+			arguments.hosts = [{serverName='localhost',serverPort='27017'}];
+		}
+
 		variables.mongoFactory = arguments.mongoFactory;
 	 	establishHostInfo();
 

--- a/core/MongoConfig.cfc
+++ b/core/MongoConfig.cfc
@@ -16,7 +16,7 @@
 	 */
 	 public function init(Array hosts, dbName='default_db', MongoFactory="#createObject('DefaultFactory')#"){
 
-	 	if (!structKeyExists(arguments, 'hosts')) {
+	 	if (!structKeyExists(arguments, 'hosts') || arrayIsEmpty(arguments.hosts)) {
 			arguments.hosts = [{serverName='localhost',serverPort='27017'}];
 		}
 

--- a/core/MongoConfig.cfc
+++ b/core/MongoConfig.cfc
@@ -16,7 +16,7 @@
 	 */
 	 public function init(Array hosts, dbName='default_db', MongoFactory="#createObject('DefaultFactory')#"){
 
-	 	if (!structKeyExist(arguments, 'hosts')) {
+	 	if (!structKeyExists(arguments, 'hosts')) {
 			arguments.hosts = [{serverName='localhost',serverPort='27017'}];
 		}
 

--- a/examples/gettingstarted.cfm
+++ b/examples/gettingstarted.cfm
@@ -282,7 +282,7 @@ h2{
 
 	function showResult( searchResult, label ){
 		writeOutput("<h2>#label#</h2>");
-		writeDump( var=searchResult.asArray(), label=label, expand="false" );
+		writeDump( var=searchResult.asArray(), label=label & '(Result from MongoDB)', expand="false" );
 		writeOutput( "<br>Total #label# in this result, accounting for skip and limit: " & searchResult.size() );
 		writeOutput( "<br>Total #label#, ignoring skip and limit: " & searchResult.totalCount() );
 		writeOutput( "<br>Query: " & searchResult.getQuery().toString() );

--- a/test/MongoTest.cfc
+++ b/test/MongoTest.cfc
@@ -445,6 +445,65 @@ function newDBObject_should_create_correct_datatypes(){
 
 }
 
+/**
+*	Confirm getLastError works and mongo has not changed it's response.
+*/
+function getLastError()
+{
+	var jColl = mongo.getMongoDBCollection(col, mongoConfig);
+	var mongoUtil = mongo.getMongoUtil();
+
+	// Create people to steal an id from
+	createPeople();
+
+	// Get the result of the last activity from CreatePeople()
+	local.lastActivity = mongo.getLastError();
+
+	// Verify the structure returned by Mongo has not changed
+	var expected = listToArray('n,ok,err');
+	local.actualKeys = structKeyArray(local.lastActivity);
+	arraySort(local.actualKeys,'text');
+	arraySort(expected,'text');
+	assertEquals(
+		 local.actualKeys
+		,expected
+		,'Mongo may have changed the getLastError() response.'
+	);
+
+	local.peeps = mongo.query(collectionName=col).search(limit="1").asArray();
+	assertFalse(
+		arrayIsEmpty(local.peeps)
+		,'Some people should have been returned.'
+	);
+
+
+	// Let's duplicate the record.
+	local.person = local.peeps[1];
+	jColl.insert([mongoUtil.toMongo(local.person)]);
+
+	// Get the result of the last activity
+	local.lastActivity = mongo.getLastError();
+
+	// Confirm we did try to duplicate an id.
+	assert(
+		 structKeyExists(local.lastActivity,'code')
+		,'Mongo should be upset a record was duplicated. Check the test.'
+	);
+
+	// We now expect the error code to exist.
+	var expected = listToArray('n,ok,err,code');
+	local.actualKeys = structKeyArray(local.lastActivity);
+	arraySort(local.actualKeys,'text');
+	arraySort(expected,'text');
+	assertEquals(
+		 local.actualKeys
+		,expected
+		,'Mongo may have changed the getLastError() response.'
+	);
+
+	return;
+}
+
  </cfscript>
 </cfcomponent>
 


### PR DESCRIPTION
I added the unit test for getLastError() and gave Mongo.cfc the ability to return getLastError().

This pull request also includes changes to the way defaults for complex objects are handled within Mongo.cfc to stop CFBuilder from crying. Thanks!
