### PR TITLE
Added an "asString" function in mongoUtil that can set a value to be str...

### DIFF
--- a/core/MongoUtil.cfc
+++ b/core/MongoUtil.cfc
@@ -60,6 +60,7 @@
 	 * Designate a value to always be evaluated as string
 	 **/
 	function asString(value){
+		if( server.coldfusion.productname eq "Railo") return value;
 		return variables.mongoFactory.getObject("net.marcesher.CFStrictTyperString").init(toString(arguments.value));
 	}
 

--- a/core/MongoUtil.cfc
+++ b/core/MongoUtil.cfc
@@ -55,6 +55,13 @@
 	function newOperationalDBObject(){
 		return dboFactory.newInstance(variables.operationTyper);
 	}
+	
+	/**
+	 * Designate a value to always be evaluated as string
+	 **/
+	function asString(value){
+		return variables.mongoFactory.getObject("net.marcesher.CFStrictTyperString").init(toString(arguments.value));
+	}
 
 	/**
 	* Create a new instance of a CFBasicDBObjectBuilder

--- a/examples/gettingstarted.cfm
+++ b/examples/gettingstarted.cfm
@@ -284,6 +284,28 @@ with ColdSpring or WireBox.
 	writeOutput("<h2>Timestamps from Doc</h2>");
 	writeOutput("Timestamp on first doc: #first['_id'].getTime()# = #mongoUtil.getDateFromDoc(first)#   <br>");
 	writeOutput("Timestamp on last doc: #last['_id'].getTime()# = #mongoUtil.getDateFromDoc(last)#   <br>");
+	
+	
+	//show how to force a value to be a string regardless of its content
+	mongoUtil = mongo.getMongoUtil();
+	celebCol = mongo.getDBCollection( "celebs" );
+	celebCol.remove( {} );
+	//asString forces a value to be string even if it looks like a number
+	celebs = [
+		{NAME = "Warren Beatty", ZIP = mongoUtil.asString("90210")},
+		{NAME = "Paul Newman", ZIP = "90210-9997"},
+		{NAME = "Eddie Murphy", ZIP = "90210-6823"},
+		{NAME = "Bill Murray", ZIP = mongoUtil.asString("90265")},
+		{NAME = "Bill Cosby", ZIP = mongoUtil.asString("90272")}
+	];
+	celebCol.saveAll( celebs );
+
+	writeOutput("<h2>mongoUtil.asString()</h2>");
+	writeOutput("<span style='color:red'>Only needed for ColdFusion!  Railo handles datatypes correctly without this method!</span><br><br>");
+	writeDump(var=celebCol.find(query={}, sort={"ZIP"=1}).asArray(), label="asString", expand="false");
+	writeOutput("The sort by zip works because the datatypes are all string.  If the numeric looking zip codes went in as numeric while the other as string, all the numbers would appear first on the list, followed by strings.");
+	
+	
 
 	//close the Mongo instance. Very important!
 	mongo.close();

--- a/java/src/net/marcesher/CFStrictTyper.java
+++ b/java/src/net/marcesher/CFStrictTyper.java
@@ -31,7 +31,9 @@ public class CFStrictTyper implements Typer {
 			return handleArray(value);		
 		} else if( value instanceof Map ){			
 			return handleMap(value);		
-		} 
+		} else if( value instanceof net.marcesher.CFStrictTyperString){
+			return value.toString();
+		}
 		
 		return value;
 	}

--- a/java/src/net/marcesher/CFStrictTyperString.java
+++ b/java/src/net/marcesher/CFStrictTyperString.java
@@ -1,0 +1,20 @@
+package net.marcesher;
+
+/**
+ * 
+ * A simple class that does nothing but to let us know this should
+ * be interpreted as a string
+ *
+ */
+public class CFStrictTyperString {
+	private String val;
+	
+	public CFStrictTyperString(String val) {
+		this.val = val;
+	}
+	
+	@Override
+	public String toString() {
+		return this.val;
+	}
+}

--- a/test/BaseTestCase.cfc
+++ b/test/BaseTestCase.cfc
@@ -73,6 +73,7 @@
 		<cfargument name="count" type="numeric" required="false" default="5"/>
 		<cfargument name="save" type="boolean" required="false" default="true"/>
 		<cfargument name="name" type="string" required="false" default="unittest"/>
+		<cfargument name="stringTest" type="boolean" required="false" default="false" />
 		<cfscript>
 		var i = 1;
 		var people = [];
@@ -81,9 +82,15 @@
 				"name"=name,
 				"age"=randRange(10,100),
 				"now"=getTickCount(),
+				"networth"=randRange(10,100) * 7.25,
 				"counter"=i,
 				inprocess=false
 			};
+			if (arguments.stringTest) {
+				person["ageAsString"] = mongo.getMongoUtil().asString(person["age"]);
+				person["networthAsString"] = mongo.getMongoUtil().asString(person["networth"]);
+				person["counterAsString"] = mongo.getMongoUtil().asString(person["counter"]);
+			}
 			arrayAppend(people, person);
 		}
 		if(save){

--- a/test/DBCollectionTest.cfc
+++ b/test/DBCollectionTest.cfc
@@ -302,6 +302,43 @@ import cfmongodb.core.*;
 		var doc = one.asArray()[1];
 		assertEquals( 3, doc.counter );
 	}
+	
+	function find_should_handle_asString_correctly() {
+		var people = createPeople(5, true, "unittest", true);
+		var all = dbCol.find({"counterAsString": 1});
+		//expect no results because it's searching as a number
+		assertEquals(0, all.size());
+		var all = dbCol.find({"counterAsString": mongo.getMongoUtil().asString("1")});
+		//expect 1 result because it's searching as a string
+		assertEquals(1, all.size());
+	}
+	
+	function find_should_handle_all_types_correctly() {
+		var people = createPeople(5, true, "unittest", true);
+		//make sure there is 5 double
+		all = dbCol.find( {"$and"= [{"name"="unittest"}, 
+										{"networth"={"$exists"=1}}, 
+										{"networth"={"$type"=1}}]} ); //type 1 is double
+		assertEquals(5, all.size());
+		
+		//make sure there is 5 integer
+		all = dbCol.find( {"$and"= [{"name"="unittest"}, 
+									{"age"={"$exists"=1}}, 
+									{"age"={"$type"=16}}]} ); //type 16 is integer
+		assertEquals(5, all.size());
+		
+		//make sure there is 5 string for "ageAsString"
+		all = dbCol.find( {"$and"= [{"name"="unittest"}, 
+									{"ageAsString"={"$exists"=1}}, 
+									{"ageAsString"={"$type"=2}}]} ); //type 2 is string
+		assertEquals(5, all.size());
+		
+		//make sure there is 5 string for "networthAsString"
+		all = dbCol.find( {"$and"= [{"name"="unittest"}, 
+									{"networthAsString"={"$exists"=1}}, 
+									{"networthAsString"={"$type"=2}}]} ); //type 2 is stirng
+		assertEquals(5, all.size());
+	}
 
 	function find_should_honor_including_fields(){
 		var people = createPeople(5, true);


### PR DESCRIPTION
Added an "asString" function in mongoUtil that can set a value to be string in mongodb

This is in reference to the issue talked about in https://groups.google.com/forum/#!topic/cfmongodb/Eeia92jt7Uo

Instead of using StringBuffer, I created a separate class for it to avoid breaking any existing implementations.
