### PR TITLE
New getDBCollection argument to support sibling DB

### DIFF
--- a/core/DBCollection.cfc
+++ b/core/DBCollection.cfc
@@ -13,12 +13,15 @@
 	/**
 	* Not intended to be invoked directly. Always fetch DBCollection objects via mongo.getDBCollection( collectionName )
 	*/
-	function init( collectionName, mongo ){
+	function init( collectionName, mongo, dbName ){
 		structAppend( variables, arguments );
 		variables.mongoUtil = mongo.getMongoUtil();
 		variables.mongoConfig = mongo.getMongoConfig();
 
-		variables.mongoDB = getMongoDB();
+		variables.mongoDB = mongo.getMongoDB();
+        if (structkeyexists(arguments,"dbName") and arguments.dbName neq variables.mongoConfig.getDBName())
+            variables.mongoDB = mongo.getMongoDB().getSisterDB(arguments.dbName);
+
 		variables.collection = mongoDB.getCollection( collectionName );
 
 		return this;
@@ -43,7 +46,7 @@
 	* Get the underlying Java driver's DB object
 	*/
 	private function getMongoDB(){
-		return variables.mongo.getMongo().getDb( variables.mongo.getMongoConfig().getDBName() );
+        return variables.mongoDB;
 	}
 
 	/**

--- a/core/Mongo.cfc
+++ b/core/Mongo.cfc
@@ -70,11 +70,11 @@
 	/**
 	* Gets a CFMongoDB DBCollection object, which wraps the java DBCollection
 	*/
-	function getDBCollection( collectionName ){
-		if( not structKeyExists( variables.collections, collectionName ) ){
-			variables.collections[ collectionName ] = createObject("component", "DBCollection" ).init( collectionName, this );
+	function getDBCollection( collectionName, dbName=getMongoConfig().getDBName() ){
+		if( not structkeyexists(variables.collections, dbName) or not structKeyExists( variables.collections[dbName], collectionName ) ){
+			variables.collections[ dbName ][ collectionName ] = createObject("component", "DBCollection" ).init( collectionName, this, dbName );
 		}
-		return variables.collections[ collectionName ];
+		return variables.collections[ dbName ][ collectionName ];
 	}
 
 

--- a/test/DBCollectionTest.cfc
+++ b/test/DBCollectionTest.cfc
@@ -19,11 +19,18 @@ import cfmongodb.core.*;
 
 		deleteCol = 'deletetests';
 		dbDeleteCol = mongo.getDBCollection( deleteCol );
+
+		siblingCol = 'siblingtests';
+		dbSiblingCol = mongo.getDBCollection( siblingCol );
+		siblingDbSiblingCol = mongo.getDBCollection( siblingCol, "cfmongodb_tests_sibling" );
+
 		super.setUp();
 	}
 
 	function tearDown(){
 		dbAtomicCol.remove({});
+		dbSiblingCol.drop();
+		siblingDbSiblingCol.drop();
 		super.tearDown();
 	}
 
@@ -509,6 +516,27 @@ import cfmongodb.core.*;
 
 	private function getIndexesFailOverride(){
 		throw("authentication failed");
+	}
+
+
+	/*    SISTER DB TEST   */
+	function getSiblingDB_returns_collection_from_sibling_db(){
+		var testdocs = [
+			{ "name":"test1" },
+			{ "name":"test2" },
+			{ "name":"test3" },
+			{ "name":"test4" }
+		];
+
+		// insert test docs into sibling database's collection
+		siblingDbSiblingCol.saveAll(testdocs);
+
+		local.thiscount = dbSiblingCol.count();
+		local.siblingcount = siblingdbSiblingCol.count();
+
+		assertTrue(local.thiscount eq 0, "Local sibling collection should have no docs, has #local.thiscount#.")
+		assertTrue(local.siblingcount eq 4, "Sibling collection should have 4 docs, has #local.siblingcount#.")
+		assertTrue(local.thiscount neq local.siblingcount, "Local sibling collection should have no docs, sibling should have 4.")
 	}
 
 


### PR DESCRIPTION
I added a test as well, I must admit I feel pretty dumb about the whole unit test thing, hopefully what I did is adequate. I basically created a new collection in the test db and a collection with the same name in a new sibling db, loaded the sibling one with a few docs, and verify there are no docs in the "local" collection.
