### PR TITLE
Added output=false to all core components

### DIFF
--- a/core/AggregationResult.cfc
+++ b/core/AggregationResult.cfc
@@ -1,4 +1,4 @@
-component accessors="true"{
+component output="false" accessors="true"{
 
 	/**
 	* use getAggregationOutput() to access the underlying Java object returned by MongoDB. See javadocs for available methods on that object

--- a/core/DBCollection.cfc
+++ b/core/DBCollection.cfc
@@ -1,4 +1,4 @@
-<cfcomponent accessors="true">
+<cfcomponent accessors="true" output="false">
 
 	<cfproperty name="mongoUtil">
 

--- a/core/MapReduceResult.cfc
+++ b/core/MapReduceResult.cfc
@@ -1,4 +1,4 @@
-component accessors="true"{
+component output="false" accessors="true"{
 
 	property name="dbCommand";
 	property name="commandResult";

--- a/core/Mongo.cfc
+++ b/core/Mongo.cfc
@@ -1,4 +1,4 @@
-<cfcomponent accessors="true">
+<cfcomponent accessors="true" output="false">
 
 	<cfproperty name="mongoConfig">
 	<cfproperty name="mongoFactory">

--- a/core/MongoClient.cfc
+++ b/core/MongoClient.cfc
@@ -1,4 +1,4 @@
-component accessors="true" extends="Mongo" {
+component output="false" accessors="true" extends="Mongo" {
 
 	/**
 	* You can init CFMongoDB in two ways:

--- a/core/MongoUtil.cfc
+++ b/core/MongoUtil.cfc
@@ -1,4 +1,4 @@
-<cfcomponent accessors="true">
+<cfcomponent output="false" accessors="true">
 
 	<cfproperty name="mongoFactory">
 

--- a/core/SearchBuilder.cfc
+++ b/core/SearchBuilder.cfc
@@ -1,4 +1,4 @@
-<cfcomponent hint="Creates a Domain Specific Language (DSL) for querying MongoDB collections.">
+<cfcomponent output="false" hint="Creates a Domain Specific Language (DSL) for querying MongoDB collections.">
 <cfscript>
 
   /*---------------------------------------------------------------------

--- a/core/SearchResult.cfc
+++ b/core/SearchResult.cfc
@@ -1,4 +1,4 @@
-<cfcomponent>
+<cfcomponent output="false">
 <cfscript>
 
 	mongoCursor = "";


### PR DESCRIPTION
I was seeing a bunch of extra whitespace in output when using cfmongodb for my i18n resource bundle layer. Adding output=false to the DBCollection.cfc component solved the issue but I figured it wouldn't hurt to add it to the rest of the components as well.

Units tests all pass.
